### PR TITLE
Fix microphone permission handling and update widget test reference

### DIFF
--- a/lib/services/chord_recognition_service.dart
+++ b/lib/services/chord_recognition_service.dart
@@ -22,17 +22,11 @@ class ChordRecognitionService {
   Future<void> startListening() async {
     final PermissionStatus status = await Permission.microphone.request();
     if (!status.isGranted) {
-
       final bool requiresSettings =
           status.isPermanentlyDenied || status.isRestricted;
       throw MicrophonePermissionException(
         requiresSettings: requiresSettings,
       );
-
-
-      throw MicrophonePermissionException();
-
-
     }
 
     if (_isRecording) {
@@ -88,7 +82,4 @@ class MicrophonePermissionException implements Exception {
 
   final bool requiresSettings;
 }
-
-
-class MicrophonePermissionException implements Exception {}
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,12 +8,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:ukitar/main.dart';
+import 'package:ukitar/app.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const UkitarApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- remove the duplicate permission exception class and unreachable throw in the chord recognition service
- update the widget test to pump the current UkitarApp entrypoint

## Testing
- not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dbe6b17ee48326bec0ed81f399c509