### PR TITLE
Fix namespace configuration for flutter_fft plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,3 +1,5 @@
+import groovy.xml.XmlSlurper
+
 allprojects {
     repositories {
         google()
@@ -11,6 +13,30 @@ subprojects {
 }
 subprojects {
     project.evaluationDependsOn(":app")
+}
+
+subprojects { project ->
+    project.afterEvaluate {
+        def isAndroidLib = project.plugins.hasPlugin("com.android.library")
+        if (!isAndroidLib) {
+            return
+        }
+
+        def hasNamespace = project.android.hasProperty("namespace") && project.android.namespace
+        if (hasNamespace) {
+            return
+        }
+
+        def manifestFile = project.file("src/main/AndroidManifest.xml")
+        if (!manifestFile.exists()) {
+            return
+        }
+
+        def manifestPackage = new XmlSlurper().parse(manifestFile).@package?.text()
+        if (manifestPackage) {
+            project.android.namespace = manifestPackage
+        }
+    }
 }
 
 tasks.register("clean", Delete) {


### PR DESCRIPTION
## Summary
- automatically assign a namespace to Android library modules that are missing one by reading their manifest package
- ensure the flutter_fft plugin continues to build with the newer Android Gradle Plugin requirements

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbee49610083268d0b5986bef3929c