### PR TITLE
Fix android namespace configuration hook

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,12 +16,7 @@ subprojects {
 }
 
 subprojects { project ->
-    project.afterEvaluate {
-        def isAndroidLib = project.plugins.hasPlugin("com.android.library")
-        if (!isAndroidLib) {
-            return
-        }
-
+    project.plugins.withId("com.android.library") {
         def hasNamespace = project.android.hasProperty("namespace") && project.android.namespace
         if (hasNamespace) {
             return


### PR DESCRIPTION
## Summary
- avoid using afterEvaluate hook when configuring android library namespaces
- use plugins.withId to ensure configuration runs only when the android library plugin is applied

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbef2e11308326ba919096a06d6cef