### PR TITLE
Raise Android minSdk to 24

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,7 +24,7 @@ android {
         applicationId = "com.example.ukitar"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        minSdk = Math.max(flutter.minSdkVersion, 24)
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName


### PR DESCRIPTION
## Summary
- raise the Android application's minSdk version to 24 to satisfy the flutter_fft dependency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbefd4974c8326b27f30f727bae2f1