### PR TITLE
Adjust home screen title color

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -19,7 +19,7 @@ class HomeScreen extends StatelessWidget {
               'Ukitar',
               style: theme.textTheme.displaySmall?.copyWith(
                 fontWeight: FontWeight.bold,
-                color: theme.colorScheme.primary,
+                color: theme.colorScheme.onSurface,
               ),
             ),
             const SizedBox(height: 16),


### PR DESCRIPTION
## Summary
- update the home screen heading to use the standard surface text color for better contrast consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dce00b79048326bbd41f531a946ff6