### PR TITLE
Adjust home screen text colors

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -25,7 +25,9 @@ class HomeScreen extends StatelessWidget {
             const SizedBox(height: 16),
             Text(
               'Learn your first ukulele chords with guided practice and real-time feedback.',
-              style: theme.textTheme.titleMedium,
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
             const Spacer(),
             _FeatureBullet(
@@ -92,6 +94,7 @@ class _FeatureBullet extends StatelessWidget {
                 title,
                 style: theme.textTheme.titleMedium?.copyWith(
                   fontWeight: FontWeight.w600,
+                  color: theme.colorScheme.onSurfaceVariant,
                 ),
               ),
               const SizedBox(height: 4),


### PR DESCRIPTION
## Summary
- update the home screen subtitle text color to match the rest of the UI palette
- adjust feature bullet titles to use the on-surface-variant grey for visual consistency

## Testing
- not run (UI-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dce121c7a083269fd78d055d13a748