### PR TITLE
Use platform channels for YouTube CTA

### DIFF
--- a/android/app/src/main/kotlin/com/example/ukitar/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/ukitar/MainActivity.kt
@@ -1,5 +1,39 @@
 package com.example.ukitar
 
+import android.content.Intent
+import android.net.Uri
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity: FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private val channelName = "ukitar.external_launcher"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName).setMethodCallHandler { call, result ->
+            if (call.method == "openUrl") {
+                val url = call.arguments as? String
+                if (url.isNullOrBlank()) {
+                    result.error("INVALID_URL", "URL was null or blank", null)
+                    return@setMethodCallHandler
+                }
+
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+
+                val packageManager = applicationContext.packageManager
+                if (intent.resolveActivity(packageManager) != null) {
+                    startActivity(intent)
+                    result.success(true)
+                } else {
+                    result.success(false)
+                }
+            } else {
+                result.notImplemented()
+            }
+        }
+    }
+}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -7,6 +7,35 @@ import UIKit
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    if let controller = window?.rootViewController as? FlutterViewController {
+      let channel = FlutterMethodChannel(
+        name: "ukitar.external_launcher",
+        binaryMessenger: controller.binaryMessenger
+      )
+
+      channel.setMethodCallHandler { call, result in
+        if call.method == "openUrl" {
+          guard let urlString = call.arguments as? String,
+                let url = URL(string: urlString) else {
+            result(FlutterError(code: "INVALID_URL", message: "URL was nil or malformed", details: nil))
+            return
+          }
+
+          DispatchQueue.main.async {
+            if UIApplication.shared.canOpenURL(url) {
+              UIApplication.shared.open(url, options: [:]) { success in
+                result(success)
+              }
+            } else {
+              result(false)
+            }
+          }
+        } else {
+          result(FlutterMethodNotImplemented)
+        }
+      }
+    }
+
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'package:ukitar/utils/url_opener.dart';
+
 import 'practice_screen.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -22,6 +24,13 @@ class HomeScreen extends StatelessWidget {
                 color: theme.colorScheme.onSurface,
               ),
             ),
+            const SizedBox(height: 8),
+            Text(
+              'by awiealissa',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
             const SizedBox(height: 16),
             Text(
               'Learn your first ukulele chords with guided practice and real-time feedback.',
@@ -29,17 +38,11 @@ class HomeScreen extends StatelessWidget {
                 color: theme.colorScheme.onSurfaceVariant,
               ),
             ),
-            const Spacer(),
+            const SizedBox(height: 32),
             _FeatureBullet(
               icon: Icons.auto_graph,
               title: 'Step-by-step course',
               description: 'Unlock new chords only after mastering the basics.',
-            ),
-            const SizedBox(height: 16),
-            _FeatureBullet(
-              icon: Icons.mic,
-              title: 'Microphone feedback',
-              description: 'Your ukulele is the controller—strum to progress.',
             ),
             const Spacer(),
             SizedBox(
@@ -59,9 +62,43 @@ class HomeScreen extends StatelessWidget {
                 child: const Text('Start Practice'),
               ),
             ),
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: OutlinedButton.icon(
+                onPressed: () => _openYoutubeChannel(context),
+                icon: const Icon(Icons.play_circle_fill),
+                label: const Text('Watch awiealissa on YouTube'),
+                style: OutlinedButton.styleFrom(
+                  foregroundColor: theme.colorScheme.primary,
+                  textStyle: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+            _FeatureBullet(
+              icon: Icons.mic,
+              title: 'Microphone feedback',
+              description: 'Your ukulele is the controller—strum to progress.',
+            ),
             const SizedBox(height: 24),
           ],
         ),
+      ),
+    );
+  }
+}
+
+Future<void> _openYoutubeChannel(BuildContext context) async {
+  const String url = 'https://www.youtube.com/@awiealissa';
+  final bool opened = await openExternalUrl(url);
+  if (!opened) {
+    final ScaffoldMessengerState? messenger = ScaffoldMessenger.maybeOf(context);
+    messenger?.showSnackBar(
+      const SnackBar(
+        content: Text('Unable to open the YouTube channel right now.'),
       ),
     );
   }

--- a/lib/utils/url_opener.dart
+++ b/lib/utils/url_opener.dart
@@ -1,0 +1,4 @@
+import 'url_opener_stub.dart'
+    if (dart.library.html) 'url_opener_web.dart' as url_opener;
+
+Future<bool> openExternalUrl(String url) => url_opener.openExternalUrl(url);

--- a/lib/utils/url_opener_stub.dart
+++ b/lib/utils/url_opener_stub.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/services.dart';
+
+const MethodChannel _channel = MethodChannel('ukitar.external_launcher');
+
+Future<bool> openExternalUrl(String url) async {
+  try {
+    final bool? opened = await _channel.invokeMethod<bool>('openUrl', url);
+    return opened ?? false;
+  } on PlatformException {
+    return false;
+  }
+}

--- a/lib/utils/url_opener_web.dart
+++ b/lib/utils/url_opener_web.dart
@@ -1,0 +1,6 @@
+import 'dart:html' as html;
+
+Future<bool> openExternalUrl(String url) async {
+  html.window.open(url, '_blank');
+  return true;
+}


### PR DESCRIPTION
## Summary
- replace the url_launcher import with a custom openExternalUrl helper
- add platform channel implementations for Android, iOS, and a web fallback to open the channel link
- wire the home screen button through the helper and show a snackbar when launching fails

## Testing
- flutter pub get *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dce811ba108326866bcbe67ba6dbeb