### PR TITLE
Fix flutter_fft dependency constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   provider: ^6.1.2
 
   # Audio / pitch detection
-  flutter_fft: ^1.2.0
+  flutter_fft: ^1.0.2+6
   permission_handler: ^11.3.1
   url_launcher: ^6.3.0
 


### PR DESCRIPTION
## Summary
- update the flutter_fft dependency constraint to ^1.0.2+6 to match the latest available release

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dceb333f5883269b309464e35d81cd