### PR TITLE
Update Android build tooling versions

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version "8.2.2" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Summary
- bump the Android Gradle Plugin to 8.2.2 to avoid the Java 21 build failure
- update the Kotlin Android plugin to 1.9.22 to stay compatible with the newer AGP version

## Testing
- not run (Flutter SDK is unavailable in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68dcebe82c188326aa35411eb969bbc5