### PR TITLE
Adjust home screen feature layout

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -45,6 +45,12 @@ class HomeScreen extends StatelessWidget {
               title: 'Step-by-step course',
               description: 'Unlock new chords only after mastering the basics.',
             ),
+            const SizedBox(height: 24),
+            _FeatureBullet(
+              icon: Icons.mic,
+              title: 'Microphone feedback',
+              description: 'Your ukulele is the controller—strum to progress.',
+            ),
             const Spacer(),
             SizedBox(
               width: double.infinity,
@@ -78,12 +84,6 @@ class HomeScreen extends StatelessWidget {
                   ),
                 ),
               ),
-            ),
-            const SizedBox(height: 24),
-            _FeatureBullet(
-              icon: Icons.mic,
-              title: 'Microphone feedback',
-              description: 'Your ukulele is the controller—strum to progress.',
             ),
             const SizedBox(height: 24),
           ],


### PR DESCRIPTION
## Summary
- place the microphone feedback feature alongside the other feature highlight
- keep the practice CTA and external link grouped toward the bottom of the screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dced2fcc8c8326b3c73ecdb9106bd3