### PR TITLE
Fix YouTube channel button to use url_launcher

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
-
 import 'package:ukitar/utils/url_opener.dart';
 
 import 'practice_screen.dart';

--- a/lib/utils/url_opener_stub.dart
+++ b/lib/utils/url_opener_stub.dart
@@ -1,12 +1,16 @@
-import 'package:flutter/services.dart';
-
-const MethodChannel _channel = MethodChannel('ukitar.external_launcher');
+import 'package:url_launcher/url_launcher.dart';
 
 Future<bool> openExternalUrl(String url) async {
-  try {
-    final bool? opened = await _channel.invokeMethod<bool>('openUrl', url);
-    return opened ?? false;
-  } on PlatformException {
+  final Uri? uri = Uri.tryParse(url);
+  if (uri == null) {
     return false;
   }
+
+  // Try launching outside the app when possible (e.g., dedicated app or browser).
+  if (await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+    return true;
+  }
+
+  // Fallback to the platform default behaviour.
+  return launchUrl(uri, mode: LaunchMode.platformDefault);
 }


### PR DESCRIPTION
## Summary
- replace the platform channel implementation in `openExternalUrl` with `url_launcher` so the YouTube button can open the channel externally
- remove the unused `url_launcher` import from the home screen

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dcee0407b483268b3b593dde9f67fb