### PR TITLE
Add exercise mode with microphone feedback screen

### DIFF
--- a/lib/screens/exercise_screen.dart
+++ b/lib/screens/exercise_screen.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../services/chord_recognition_service.dart';
+import '../viewmodels/exercise_view_model.dart';
+import '../widgets/chord_diagram.dart';
+
+class ExerciseScreen extends StatelessWidget {
+  const ExerciseScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider<ExerciseViewModel>(
+      create: (_) => ExerciseViewModel(ChordRecognitionService()),
+      child: const _ExerciseView(),
+    );
+  }
+}
+
+class _ExerciseView extends StatelessWidget {
+  const _ExerciseView();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Exercises'),
+      ),
+      body: Consumer<ExerciseViewModel>(
+        builder: (BuildContext context, ExerciseViewModel model, _) {
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'Play along with the microphone to get immediate feedback.',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: theme.colorScheme.onSurface,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                _ChordCard(model: model),
+                const SizedBox(height: 24),
+                _StatusBanner(model: model),
+                const SizedBox(height: 24),
+                if (model.showOpenSettingsButton)
+                  FilledButton.icon(
+                    onPressed: model.openSystemSettings,
+                    icon: const Icon(Icons.settings),
+                    label: const Text('Open Settings'),
+                  )
+                else
+                  Row(
+                    children: <Widget>[
+                      Expanded(
+                        child: FilledButton(
+                          onPressed: model.isListening
+                              ? model.stopListening
+                              : model.startListening,
+                          style: FilledButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(vertical: 18),
+                          ),
+                          child: Text(model.isListening
+                              ? 'Stop Listening'
+                              : 'Start Listening'),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: model.isPreparingNextChord
+                              ? null
+                              : model.skipToNextChord,
+                          style: OutlinedButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(vertical: 18),
+                          ),
+                          child: const Text('Next Chord'),
+                        ),
+                      ),
+                    ],
+                  ),
+                const SizedBox(height: 16),
+                if (!model.showOpenSettingsButton)
+                  TextButton.icon(
+                    onPressed: model.isPreparingNextChord
+                        ? null
+                        : model.retryCurrentChord,
+                    icon: const Icon(Icons.refresh),
+                    label: const Text('Try Again'),
+                  ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ChordCard extends StatelessWidget {
+  const _ChordCard({required this.model});
+
+  final ExerciseViewModel model;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+
+    return Card(
+      elevation: 0,
+      color: colorScheme.surfaceVariant,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(24),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              model.currentChord.name,
+              style: theme.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: colorScheme.onSurface,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Strum this chord cleanly when listening starts to score a success.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 20),
+            Center(child: ChordDiagram(chord: model.currentChord)),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusBanner extends StatelessWidget {
+  const _StatusBanner({required this.model});
+
+  final ExerciseViewModel model;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colorScheme = theme.colorScheme;
+
+    final IconData icon;
+    final Color backgroundColor;
+    final Color foregroundColor;
+
+    if (model.lastAttemptSuccessful == true) {
+      icon = Icons.check_circle;
+      backgroundColor = colorScheme.primaryContainer;
+      foregroundColor = colorScheme.onPrimaryContainer;
+    } else if (model.lastAttemptSuccessful == false) {
+      icon = Icons.error_outline;
+      backgroundColor = colorScheme.errorContainer;
+      foregroundColor = colorScheme.onErrorContainer;
+    } else if (model.isListening) {
+      icon = Icons.hearing;
+      backgroundColor = colorScheme.secondaryContainer;
+      foregroundColor = colorScheme.onSecondaryContainer;
+    } else {
+      icon = Icons.music_note;
+      backgroundColor = colorScheme.surfaceVariant;
+      foregroundColor = colorScheme.onSurfaceVariant;
+    }
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(icon, color: foregroundColor, size: 28),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Text(
+              model.statusMessage,
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: foregroundColor,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:ukitar/utils/url_opener.dart';
 
+import 'exercise_screen.dart';
 import 'practice_screen.dart';
 
 const Color _youtubeRed = Color(0xFFFF0000);
@@ -72,13 +73,13 @@ class HomeScreen extends StatelessWidget {
             const SizedBox(height: 12),
             SizedBox(
               width: double.infinity,
-              child: OutlinedButton(
+              child: FilledButton(
                 onPressed: () {
                   Navigator.of(context).push(MaterialPageRoute<void>(
-                    builder: (BuildContext context) => const PracticeScreen(),
+                    builder: (BuildContext context) => const ExerciseScreen(),
                   ));
                 },
-                style: OutlinedButton.styleFrom(
+                style: FilledButton.styleFrom(
                   padding: const EdgeInsets.symmetric(vertical: 20),
                   textStyle: theme.textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.w600,

--- a/lib/viewmodels/exercise_view_model.dart
+++ b/lib/viewmodels/exercise_view_model.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+
+import '../data/chord_library.dart';
+import '../models/chord.dart';
+import '../services/chord_recognition_service.dart';
+
+class ExerciseViewModel extends ChangeNotifier {
+  ExerciseViewModel(this._chordRecognitionService)
+      : chords = ChordLibrary.beginnerCourse() {
+    _frequencySubscription =
+        _chordRecognitionService.frequencyStream.listen(_handleFrequency);
+    _prepareNextChord(initial: true);
+  }
+
+  final ChordRecognitionService _chordRecognitionService;
+  final List<Chord> chords;
+
+  late final StreamSubscription<double> _frequencySubscription;
+  final Random _random = Random();
+  final Set<int> _matchedStrings = <int>{};
+
+  static const Duration _attemptTimeout = Duration(milliseconds: 1500);
+  static const Duration _nextChordDelay = Duration(seconds: 2);
+
+  late Chord currentChord;
+  int? _currentChordIndex;
+
+  bool isListening = false;
+  bool? lastAttemptSuccessful;
+  bool showOpenSettingsButton = false;
+  bool isPreparingNextChord = false;
+
+  String statusMessage = 'Press "Start Listening" to begin.';
+
+  Timer? _attemptTimer;
+  bool _disposed = false;
+
+  Future<void> startListening() async {
+    if (isPreparingNextChord) {
+      return;
+    }
+
+    lastAttemptSuccessful = null;
+    statusMessage = 'Listening... Play the ${currentChord.name} chord.';
+    showOpenSettingsButton = false;
+    _matchedStrings.clear();
+    notifyListeners();
+
+    try {
+      await _chordRecognitionService.startListening();
+      isListening = true;
+    } on MicrophonePermissionException catch (error) {
+      showOpenSettingsButton = error.requiresSettings;
+      statusMessage = error.requiresSettings
+          ? 'Microphone access is disabled. Tap below to grant permission.'
+          : 'Microphone permission is required to listen.';
+    } catch (error) {
+      statusMessage = 'Could not access the microphone: $error';
+    }
+
+    notifyListeners();
+  }
+
+  Future<void> stopListening({bool silent = false}) async {
+    await _chordRecognitionService.stopListening();
+    isListening = false;
+    _attemptTimer?.cancel();
+    _attemptTimer = null;
+
+    if (!silent && lastAttemptSuccessful == null && _matchedStrings.isNotEmpty) {
+      lastAttemptSuccessful = false;
+      statusMessage =
+          'Almost! Try strumming all strings of ${currentChord.name} cleanly.';
+    }
+
+    notifyListeners();
+  }
+
+  Future<void> retryCurrentChord() async {
+    await stopListening(silent: true);
+    lastAttemptSuccessful = null;
+    isPreparingNextChord = false;
+    statusMessage =
+        'Ready when you are. Press "Start Listening" and strum ${currentChord.name}.';
+    _matchedStrings.clear();
+    notifyListeners();
+  }
+
+  Future<void> skipToNextChord() async {
+    await stopListening(silent: true);
+    _prepareNextChord();
+  }
+
+  Future<void> openSystemSettings() async {
+    final bool granted = await _chordRecognitionService.openSystemSettings();
+    if (granted) {
+      showOpenSettingsButton = false;
+      statusMessage =
+          'Microphone access granted. Press "Start Listening" to continue.';
+    } else {
+      statusMessage =
+          'Microphone permission is still disabled. Please enable it to continue.';
+    }
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _disposed = true;
+    unawaited(_chordRecognitionService.dispose());
+    unawaited(_frequencySubscription.cancel());
+    _attemptTimer?.cancel();
+    super.dispose();
+  }
+
+  void _prepareNextChord({bool initial = false}) {
+    if (chords.isEmpty) {
+      throw StateError('No chords available for exercises.');
+    }
+
+    int nextIndex = _random.nextInt(chords.length);
+    final int? previousIndex = _currentChordIndex;
+    if (!initial && chords.length > 1 && previousIndex != null) {
+      while (nextIndex == previousIndex) {
+        nextIndex = _random.nextInt(chords.length);
+      }
+    }
+
+    _currentChordIndex = nextIndex;
+    currentChord = chords[nextIndex];
+
+    _matchedStrings.clear();
+    lastAttemptSuccessful = null;
+    isPreparingNextChord = false;
+    statusMessage =
+        'Try strumming ${currentChord.name}. Press "Start Listening" when ready.';
+
+    notifyListeners();
+  }
+
+  void _handleFrequency(double frequency) {
+    if (!isListening) {
+      return;
+    }
+
+    final int? matchedString =
+        currentChord.matchFrequency(frequency, toleranceCents: 35);
+
+    if (matchedString == null) {
+      return;
+    }
+
+    final bool isNew = _matchedStrings.add(matchedString);
+    if (!isNew) {
+      return;
+    }
+
+    _restartAttemptTimer();
+    statusMessage =
+        'Heard the ${currentChord.stringLabel(matchedString)} string (${currentChord.notes[matchedString].noteName}).';
+
+    if (_matchedStrings.length >= currentChord.notes.length) {
+      _registerSuccessfulAttempt();
+    }
+
+    notifyListeners();
+  }
+
+  void _restartAttemptTimer() {
+    _attemptTimer?.cancel();
+    _attemptTimer = Timer(_attemptTimeout, _handleAttemptTimeout);
+  }
+
+  void _handleAttemptTimeout() {
+    _attemptTimer = null;
+    if (_matchedStrings.isEmpty) {
+      return;
+    }
+
+    _matchedStrings.clear();
+    if (isListening) {
+      lastAttemptSuccessful = false;
+      statusMessage =
+          'Almost! Try strumming the full ${currentChord.name} chord again.';
+      notifyListeners();
+    }
+  }
+
+  Future<void> _registerSuccessfulAttempt() async {
+    await stopListening(silent: true);
+    lastAttemptSuccessful = true;
+    isPreparingNextChord = true;
+    statusMessage =
+        'Great job! That sounded like ${currentChord.name}. Preparing the next chord...';
+    notifyListeners();
+
+    Future<void>.delayed(_nextChordDelay, () {
+      if (_disposed) {
+        return;
+      }
+      _prepareNextChord();
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add an exercises screen that listens via the microphone and guides the user through random chords
- implement a dedicated exercise view model to coordinate listening, evaluation, and chord rotation
- update the home screen to link to the new exercises experience and align the button styling

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd0b4582e083268acaac93d260c1a1