### PR TITLE
Hide chord diagrams by default in the exercise screen

### DIFF
--- a/lib/screens/exercise_screen.dart
+++ b/lib/screens/exercise_screen.dart
@@ -136,7 +136,24 @@ class _ChordCard extends StatelessWidget {
               ),
             ),
             const SizedBox(height: 20),
-            Center(child: ChordDiagram(chord: model.currentChord)),
+            if (model.isChordPatternVisible) ...<Widget>[
+              Center(child: ChordDiagram(chord: model.currentChord)),
+              const SizedBox(height: 16),
+              Center(
+                child: TextButton.icon(
+                  onPressed: model.toggleChordPatternVisibility,
+                  icon: const Icon(Icons.visibility_off),
+                  label: const Text('Hide Chord Pattern'),
+                ),
+              ),
+            ] else
+              Center(
+                child: FilledButton.tonalIcon(
+                  onPressed: model.toggleChordPatternVisibility,
+                  icon: const Icon(Icons.visibility),
+                  label: const Text('Show Chord Pattern'),
+                ),
+              ),
           ],
         ),
       ),

--- a/lib/viewmodels/exercise_view_model.dart
+++ b/lib/viewmodels/exercise_view_model.dart
@@ -32,6 +32,7 @@ class ExerciseViewModel extends ChangeNotifier {
   bool? lastAttemptSuccessful;
   bool showOpenSettingsButton = false;
   bool isPreparingNextChord = false;
+  bool isChordPatternVisible = false;
 
   String statusMessage = 'Press "Start Listening" to begin.';
 
@@ -83,6 +84,7 @@ class ExerciseViewModel extends ChangeNotifier {
     await stopListening(silent: true);
     lastAttemptSuccessful = null;
     isPreparingNextChord = false;
+    isChordPatternVisible = false;
     statusMessage =
         'Ready when you are. Press "Start Listening" and strum ${currentChord.name}.';
     _matchedStrings.clear();
@@ -92,6 +94,11 @@ class ExerciseViewModel extends ChangeNotifier {
   Future<void> skipToNextChord() async {
     await stopListening(silent: true);
     _prepareNextChord();
+  }
+
+  void toggleChordPatternVisibility() {
+    isChordPatternVisible = !isChordPatternVisible;
+    notifyListeners();
   }
 
   Future<void> openSystemSettings() async {
@@ -135,6 +142,7 @@ class ExerciseViewModel extends ChangeNotifier {
     _matchedStrings.clear();
     lastAttemptSuccessful = null;
     isPreparingNextChord = false;
+    isChordPatternVisible = false;
     statusMessage =
         'Try strumming ${currentChord.name}. Press "Start Listening" when ready.';
 


### PR DESCRIPTION
## Summary
- hide the chord diagram on the exercise screen until the user requests it
- provide toggle controls to reveal or hide the chord pattern on demand
- reset the visibility state whenever the exercise advances or retries

## Testing
- flutter analyze (fails: Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd0ca76bbc83269007c8d839301d0f