### PR TITLE
Add help tip link to awiealissa video on practice screen

### DIFF
--- a/lib/screens/practice_screen.dart
+++ b/lib/screens/practice_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../utils/url_opener.dart';
 import '../viewmodels/practice_view_model.dart';
 import '../widgets/chord_diagram.dart';
 
@@ -122,6 +123,50 @@ class _PracticeScreenState extends State<PracticeScreen> {
                                 ),
                               ],
                             ),
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(vertical: 4.0),
+                          child: Row(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: <Widget>[
+                              Text(
+                                '•  ',
+                                style: textTheme.bodyMedium?.copyWith(
+                                  color: secondaryTextColor,
+                                ),
+                              ),
+                              Expanded(
+                                child: Row(
+                                  crossAxisAlignment: CrossAxisAlignment.center,
+                                  children: <Widget>[
+                                    Expanded(
+                                      child: Text(
+                                        'Do you need additional help? Check out the explanation by awiealissa',
+                                        style: textTheme.bodyMedium?.copyWith(
+                                          height: 1.4,
+                                          color: secondaryTextColor,
+                                        ),
+                                      ),
+                                    ),
+                                    IconButton(
+                                      tooltip: 'Watch on YouTube',
+                                      onPressed: () {
+                                        unawaited(
+                                          openExternalUrl(
+                                            'https://www.youtube.com/watch?v=MLuYBcEVlYs',
+                                          ),
+                                        );
+                                      },
+                                      icon: Icon(
+                                        Icons.ondemand_video,
+                                        color: colorScheme.primary,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ],


### PR DESCRIPTION
## Summary
- import the shared URL opener to use on the practice screen
- append a help tip that links to awiealissa's YouTube explanation with an icon button

## Testing
- flutter test *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1275792483268a21fbce4c3648a6