### PR TITLE
Add guitar instrument support and selection

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,31 +1,24 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-
 import 'screens/home_screen.dart';
-import 'services/chord_recognition_service.dart';
-import 'viewmodels/practice_view_model.dart';
 
 class UkitarApp extends StatelessWidget {
   const UkitarApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider<PracticeViewModel>(
-      create: (_) => PracticeViewModel(ChordRecognitionService()),
-      child: MaterialApp(
-        title: 'Ukitar',
-        debugShowCheckedModeBanner: false,
-        theme: ThemeData(
-          colorScheme: ColorScheme.fromSeed(
-            seedColor: Colors.teal,
-            brightness: Brightness.light,
-          ),
-          scaffoldBackgroundColor: const Color(0xFFF8FAFB),
-          useMaterial3: true,
-          textTheme: Typography.englishLike2021.apply(fontSizeFactor: 1.0),
+    return MaterialApp(
+      title: 'Ukitar',
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.teal,
+          brightness: Brightness.light,
         ),
-        home: const HomeScreen(),
+        scaffoldBackgroundColor: const Color(0xFFF8FAFB),
+        useMaterial3: true,
+        textTheme: Typography.englishLike2021.apply(fontSizeFactor: 1.0),
       ),
+      home: const HomeScreen(),
     );
   }
 }

--- a/lib/data/chord_library.dart
+++ b/lib/data/chord_library.dart
@@ -1,10 +1,20 @@
 import '../models/chord.dart';
+import '../models/instrument.dart';
 
-/// Provides curated ukulele chords for the beginner course.
+/// Provides curated chords for supported instruments.
 class ChordLibrary {
   const ChordLibrary._();
 
-  static List<Chord> beginnerCourse() {
+  static List<Chord> beginnerCourse(InstrumentType instrument) {
+    switch (instrument) {
+      case InstrumentType.ukulele:
+        return _ukuleleBeginnerCourse();
+      case InstrumentType.guitar:
+        return _guitarBeginnerCourse();
+    }
+  }
+
+  static List<Chord> _ukuleleBeginnerCourse() {
     return <Chord>[
       Chord(
         id: 'c-major',
@@ -18,6 +28,7 @@ class ChordLibrary {
           'Keep your wrist relaxed so the ring finger arches cleanly.',
           'Strum slowly to let every string ring out.',
         ],
+        stringTunings: _ukuleleTunings,
       ),
       Chord(
         id: 'a-minor',
@@ -31,6 +42,7 @@ class ChordLibrary {
           'Press the second fret with your middle finger and keep other strings open.',
           'Make sure the fingertip stays vertical to avoid muting neighbouring strings.',
         ],
+        stringTunings: _ukuleleTunings,
       ),
       Chord(
         id: 'f-major',
@@ -45,6 +57,7 @@ class ChordLibrary {
           'Let your middle finger reach over to the second fret of the G string.',
           'Keep your thumb behind the neck to reduce tension.',
         ],
+        stringTunings: _ukuleleTunings,
       ),
       Chord(
         id: 'g-major',
@@ -60,7 +73,92 @@ class ChordLibrary {
           'Form a loose triangle shape with your fingers.',
           'Check that each string rings clearly before strumming.',
         ],
+        stringTunings: _ukuleleTunings,
       ),
     ];
   }
+
+  static List<Chord> _guitarBeginnerCourse() {
+    return <Chord>[
+      Chord(
+        id: 'e-minor',
+        name: 'E Minor',
+        description:
+            'A comfortable starter chord that uses two fingers while letting the rest of the strings ring open.',
+        fingerPositions: const <ChordFingerPosition>[
+          ChordFingerPosition(stringIndex: 1, fret: 2, fingerNumber: 2),
+          ChordFingerPosition(stringIndex: 2, fret: 2, fingerNumber: 3),
+        ],
+        tips: const <String>[
+          'Curl your fingers so the open strings ring clearly.',
+          'Strum all six strings with an even motion.',
+        ],
+        stringTunings: _guitarTunings,
+      ),
+      Chord(
+        id: 'g-major',
+        name: 'G Major',
+        description:
+            'Introduces reaching across the neck with three fingers to create a rich full sound.',
+        fingerPositions: const <ChordFingerPosition>[
+          ChordFingerPosition(stringIndex: 0, fret: 3, fingerNumber: 2),
+          ChordFingerPosition(stringIndex: 1, fret: 2, fingerNumber: 1),
+          ChordFingerPosition(stringIndex: 5, fret: 3, fingerNumber: 3),
+        ],
+        tips: const <String>[
+          'Let your wrist drop slightly so the fingers reach both sides of the fretboard.',
+          'Keep the B string relaxed to ring open for a bright harmony.',
+        ],
+        stringTunings: _guitarTunings,
+      ),
+      Chord(
+        id: 'e-major',
+        name: 'E Major',
+        description:
+            'Builds on E minor by adding the index finger for a brighter, confident sound.',
+        fingerPositions: const <ChordFingerPosition>[
+          ChordFingerPosition(stringIndex: 1, fret: 2, fingerNumber: 2),
+          ChordFingerPosition(stringIndex: 2, fret: 2, fingerNumber: 3),
+          ChordFingerPosition(stringIndex: 3, fret: 1, fingerNumber: 1),
+        ],
+        tips: const <String>[
+          'Press the first fret gently with the tip of your index finger to avoid muting the E string.',
+          'Strum confidently from the low E string through the high E string.',
+        ],
+        stringTunings: _guitarTunings,
+      ),
+      Chord(
+        id: 'c-major-guitar',
+        name: 'C Major',
+        description:
+            'Practise finger independence by stretching across three frets while letting the E strings ring.',
+        fingerPositions: const <ChordFingerPosition>[
+          ChordFingerPosition(stringIndex: 1, fret: 3, fingerNumber: 3),
+          ChordFingerPosition(stringIndex: 2, fret: 2, fingerNumber: 2),
+          ChordFingerPosition(stringIndex: 4, fret: 1, fingerNumber: 1),
+        ],
+        tips: const <String>[
+          'Angle your fingers so the open G and high E strings ring freely.',
+          'Keep your thumb centred on the back of the neck for better reach.',
+        ],
+        stringTunings: _guitarTunings,
+      ),
+    ];
+  }
+
+  static const List<StringTuning> _ukuleleTunings = <StringTuning>[
+    StringTuning(label: 'G', midi: 67),
+    StringTuning(label: 'C', midi: 60),
+    StringTuning(label: 'E', midi: 64),
+    StringTuning(label: 'A', midi: 69),
+  ];
+
+  static const List<StringTuning> _guitarTunings = <StringTuning>[
+    StringTuning(label: 'E', midi: 40),
+    StringTuning(label: 'A', midi: 45),
+    StringTuning(label: 'D', midi: 50),
+    StringTuning(label: 'G', midi: 55),
+    StringTuning(label: 'B', midi: 59),
+    StringTuning(label: 'E', midi: 64),
+  ];
 }

--- a/lib/models/chord.dart
+++ b/lib/models/chord.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-/// Represents a ukulele chord with its diagram information and expected notes.
+/// Represents a chord with its diagram information and expected notes.
 class Chord {
   Chord({
     required this.id,
@@ -8,6 +8,7 @@ class Chord {
     required this.description,
     required this.fingerPositions,
     required this.tips,
+    required this.stringTunings,
   }) {
     _notes = _buildNotes();
   }
@@ -17,20 +18,15 @@ class Chord {
   final String description;
   final List<ChordFingerPosition> fingerPositions;
   final List<String> tips;
+  final List<StringTuning> stringTunings;
 
   late final List<ChordNote> _notes;
 
-  /// Standard tuning for ukulele strings: G, C, E, A.
-  static const List<_StringTuning> _stringTunings = <_StringTuning>[
-    _StringTuning(label: 'G', midi: 67),
-    _StringTuning(label: 'C', midi: 60),
-    _StringTuning(label: 'E', midi: 64),
-    _StringTuning(label: 'A', midi: 69),
-  ];
+  int get stringCount => stringTunings.length;
 
   /// Returns the strings (0-3) to fret mapping for this chord.
   List<int> get stringFrets {
-    final List<int> frets = List<int>.filled(_stringTunings.length, 0);
+    final List<int> frets = List<int>.filled(stringTunings.length, 0);
     for (final ChordFingerPosition finger in fingerPositions) {
       frets[finger.stringIndex] = max(frets[finger.stringIndex], finger.fret);
     }
@@ -55,10 +51,10 @@ class Chord {
     return null;
   }
 
-  String stringLabel(int index) => _stringTunings[index].label;
+  String stringLabel(int index) => stringTunings[index].label;
 
   ChordNote _buildNoteForString(int stringIndex, int fret) {
-    final _StringTuning tuning = _stringTunings[stringIndex];
+    final StringTuning tuning = stringTunings[stringIndex];
     final int midi = tuning.midi + fret;
     final double frequency = 440.0 * pow(2, (midi - 69) / 12).toDouble();
 
@@ -106,7 +102,7 @@ class ChordFingerPosition {
     required this.fingerNumber,
   });
 
-  /// Zero-based index of the string (0 = G string, 3 = A string).
+  /// Zero-based index of the string (0 = lowest pitch string).
   final int stringIndex;
 
   /// Fret number (0 indicates an open string).
@@ -130,8 +126,8 @@ class ChordNote {
   final double frequency;
 }
 
-class _StringTuning {
-  const _StringTuning({required this.label, required this.midi});
+class StringTuning {
+  const StringTuning({required this.label, required this.midi});
 
   final String label;
   final int midi;

--- a/lib/models/instrument.dart
+++ b/lib/models/instrument.dart
@@ -1,0 +1,33 @@
+enum InstrumentType {
+  ukulele,
+  guitar,
+}
+
+extension InstrumentTypeX on InstrumentType {
+  String get displayName {
+    switch (this) {
+      case InstrumentType.ukulele:
+        return 'Ukulele';
+      case InstrumentType.guitar:
+        return 'Guitar';
+    }
+  }
+
+  String get description {
+    switch (this) {
+      case InstrumentType.ukulele:
+        return 'Bright four-string starter instrument.';
+      case InstrumentType.guitar:
+        return 'Six-string classic for versatile playing.';
+    }
+  }
+
+  String get noun {
+    switch (this) {
+      case InstrumentType.ukulele:
+        return 'ukulele';
+      case InstrumentType.guitar:
+        return 'guitar';
+    }
+  }
+}

--- a/lib/screens/exercise_screen.dart
+++ b/lib/screens/exercise_screen.dart
@@ -1,17 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../models/instrument.dart';
 import '../services/chord_recognition_service.dart';
 import '../viewmodels/exercise_view_model.dart';
 import '../widgets/chord_diagram.dart';
 
 class ExerciseScreen extends StatelessWidget {
-  const ExerciseScreen({super.key});
+  const ExerciseScreen({super.key, required this.instrument});
+
+  final InstrumentType instrument;
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider<ExerciseViewModel>(
-      create: (_) => ExerciseViewModel(ChordRecognitionService()),
+      create: (_) => ExerciseViewModel(ChordRecognitionService(), instrument),
       child: const _ExerciseView(),
     );
   }
@@ -26,7 +29,7 @@ class _ExerciseView extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Exercises'),
+        title: Text('Exercises • ${context.watch<ExerciseViewModel>().instrumentLabel}'),
       ),
       body: Consumer<ExerciseViewModel>(
         builder: (BuildContext context, ExerciseViewModel model, _) {

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,17 +1,27 @@
 import 'package:flutter/material.dart';
 import 'package:ukitar/utils/url_opener.dart';
 
+import '../models/instrument.dart';
 import 'exercise_screen.dart';
 import 'practice_screen.dart';
 
 const Color _youtubeRed = Color(0xFFFF0000);
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  InstrumentType _selectedInstrument = InstrumentType.ukulele;
 
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
+    final String instrumentName = _selectedInstrument.displayName;
+    final String instrumentNoun = _selectedInstrument.noun;
     return Scaffold(
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 32.0, vertical: 48.0),
@@ -49,7 +59,7 @@ class HomeScreen extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             Text(
-              'Learn your first ukulele chords with guided practice and real-time feedback.',
+              'Learn your first $instrumentNoun chords with guided practice and real-time feedback.',
               style: theme.textTheme.titleMedium?.copyWith(
                 color: theme.colorScheme.onSurfaceVariant,
               ),
@@ -64,15 +74,25 @@ class HomeScreen extends StatelessWidget {
             _FeatureBullet(
               icon: Icons.mic,
               title: 'Microphone feedback',
-              description: 'Your ukulele is the controller—strum to progress.',
+              description: 'Your instrument is the controller—strum to progress.',
             ),
             const Spacer(),
+            Text(
+              'Currently learning: $instrumentName',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: theme.colorScheme.onSurface,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 12),
             SizedBox(
               width: double.infinity,
               child: FilledButton(
                 onPressed: () {
                   Navigator.of(context).push(MaterialPageRoute<void>(
-                    builder: (BuildContext context) => const PracticeScreen(),
+                    builder: (BuildContext context) => PracticeScreen(
+                      instrument: _selectedInstrument,
+                    ),
                   ));
                 },
                 style: FilledButton.styleFrom(
@@ -88,9 +108,25 @@ class HomeScreen extends StatelessWidget {
             SizedBox(
               width: double.infinity,
               child: FilledButton(
+                onPressed: _showInstrumentPicker,
+                style: FilledButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 20),
+                  textStyle: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                child: const Text('Choose Instrument'),
+              ),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton(
                 onPressed: () {
                   Navigator.of(context).push(MaterialPageRoute<void>(
-                    builder: (BuildContext context) => const ExerciseScreen(),
+                    builder: (BuildContext context) => ExerciseScreen(
+                      instrument: _selectedInstrument,
+                    ),
                   ));
                 },
                 style: FilledButton.styleFrom(
@@ -122,6 +158,67 @@ class HomeScreen extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Future<void> _showInstrumentPicker() async {
+    final ThemeData theme = Theme.of(context);
+    final InstrumentType? result = await showDialog<InstrumentType>(
+      context: context,
+      builder: (BuildContext context) {
+        return SimpleDialog(
+          title: const Text('Choose instrument'),
+          children: <Widget>[
+            for (final InstrumentType instrument in InstrumentType.values)
+              SimpleDialogOption(
+                onPressed: () => Navigator.of(context).pop(instrument),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Icon(
+                      instrument == _selectedInstrument
+                          ? Icons.radio_button_checked
+                          : Icons.radio_button_off,
+                      color: instrument == _selectedInstrument
+                          ? theme.colorScheme.primary
+                          : theme.colorScheme.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text(
+                            instrument.displayName,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              color: theme.colorScheme.onSurface,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            instrument.description,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        );
+      },
+    );
+
+    if (!mounted || result == null || result == _selectedInstrument) {
+      return;
+    }
+
+    setState(() {
+      _selectedInstrument = result;
+    });
   }
 }
 

--- a/lib/screens/practice_screen.dart
+++ b/lib/screens/practice_screen.dart
@@ -3,50 +3,68 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../models/instrument.dart';
+import '../services/chord_recognition_service.dart';
 import '../utils/url_opener.dart';
 import '../viewmodels/practice_view_model.dart';
 import '../widgets/chord_diagram.dart';
 
-class PracticeScreen extends StatefulWidget {
-  const PracticeScreen({super.key});
+class PracticeScreen extends StatelessWidget {
+  const PracticeScreen({super.key, required this.instrument});
 
-  @override
-  State<PracticeScreen> createState() => _PracticeScreenState();
-}
-
-class _PracticeScreenState extends State<PracticeScreen> {
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final PracticeViewModel model = context.read<PracticeViewModel>();
-      unawaited(model.resetAttempt());
-    });
-  }
+  final InstrumentType instrument;
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Practice'),
-      ),
-      body: Consumer<PracticeViewModel>(
-        builder: (BuildContext context, PracticeViewModel model, _) {
-          final ColorScheme colorScheme = Theme.of(context).colorScheme;
-          final TextTheme textTheme = Theme.of(context).textTheme;
-          final Color primaryTextColor = colorScheme.onSurface;
-          final Color secondaryTextColor = colorScheme.onSurfaceVariant;
+    return ChangeNotifierProvider<PracticeViewModel>(
+      create: (_) => PracticeViewModel(ChordRecognitionService(), instrument),
+      child: const _PracticeView(),
+    );
+  }
+}
 
-          return SingleChildScrollView(
+class _PracticeView extends StatelessWidget {
+  const _PracticeView();
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<PracticeViewModel>(
+      builder: (BuildContext context, PracticeViewModel model, _) {
+        final ThemeData theme = Theme.of(context);
+        final ColorScheme colorScheme = theme.colorScheme;
+        final TextTheme textTheme = theme.textTheme;
+        final Color primaryTextColor = colorScheme.onSurface;
+        final Color secondaryTextColor = colorScheme.onSurfaceVariant;
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text('Practice • ${model.instrumentLabel}'),
+          ),
+          body: SingleChildScrollView(
             padding: const EdgeInsets.all(24),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                Text(
-                  'Beginner progression',
-                  style: textTheme.titleMedium?.copyWith(
-                    color: primaryTextColor,
-                  ),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    Expanded(
+                      child: Text(
+                        'Beginner progression',
+                        style: textTheme.titleMedium?.copyWith(
+                          color: primaryTextColor,
+                        ),
+                      ),
+                    ),
+                    Chip(
+                      label: Text(model.instrumentLabel),
+                      backgroundColor: colorScheme.primaryContainer,
+                      labelStyle: textTheme.labelLarge?.copyWith(
+                        color: colorScheme.onPrimaryContainer,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
                 ),
                 const SizedBox(height: 12),
                 Wrap(
@@ -177,9 +195,9 @@ class _PracticeScreenState extends State<PracticeScreen> {
                 _FeedbackCard(model: model),
               ],
             ),
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/viewmodels/exercise_view_model.dart
+++ b/lib/viewmodels/exercise_view_model.dart
@@ -5,11 +5,12 @@ import 'package:flutter/foundation.dart';
 
 import '../data/chord_library.dart';
 import '../models/chord.dart';
+import '../models/instrument.dart';
 import '../services/chord_recognition_service.dart';
 
 class ExerciseViewModel extends ChangeNotifier {
-  ExerciseViewModel(this._chordRecognitionService)
-      : chords = ChordLibrary.beginnerCourse() {
+  ExerciseViewModel(this._chordRecognitionService, this.instrument)
+      : chords = ChordLibrary.beginnerCourse(instrument) {
     _frequencySubscription =
         _chordRecognitionService.frequencyStream.listen(_handleFrequency);
     _prepareNextChord(initial: true);
@@ -17,6 +18,7 @@ class ExerciseViewModel extends ChangeNotifier {
 
   final ChordRecognitionService _chordRecognitionService;
   final List<Chord> chords;
+  final InstrumentType instrument;
 
   late final StreamSubscription<double> _frequencySubscription;
   final Random _random = Random();
@@ -35,6 +37,8 @@ class ExerciseViewModel extends ChangeNotifier {
   bool isChordPatternVisible = false;
 
   String statusMessage = 'Press "Start Listening" to begin.';
+
+  String get instrumentLabel => instrument.displayName;
 
   Timer? _attemptTimer;
   bool _disposed = false;

--- a/lib/viewmodels/practice_view_model.dart
+++ b/lib/viewmodels/practice_view_model.dart
@@ -4,17 +4,20 @@ import 'package:flutter/foundation.dart';
 
 import '../data/chord_library.dart';
 import '../models/chord.dart';
+import '../models/instrument.dart';
 import '../services/chord_recognition_service.dart';
 
 class PracticeViewModel extends ChangeNotifier {
-  PracticeViewModel(this._chordRecognitionService)
-      : chords = ChordLibrary.beginnerCourse() {
+  PracticeViewModel(this._chordRecognitionService, this.instrument)
+      : chords = ChordLibrary.beginnerCourse(instrument) {
     _frequencySubscription =
         _chordRecognitionService.frequencyStream.listen(_handleFrequency);
+    unawaited(resetAttempt());
   }
 
   final ChordRecognitionService _chordRecognitionService;
   final List<Chord> chords;
+  final InstrumentType instrument;
 
   late final StreamSubscription<double> _frequencySubscription;
 
@@ -44,6 +47,8 @@ class PracticeViewModel extends ChangeNotifier {
   List<int> get matchedStrings => _matchedStrings.toList(growable: false);
 
   int get requiredRepetitions => repetitionsRequired;
+
+  String get instrumentLabel => instrument.displayName;
 
   double get repetitionProgress =>
       completedRepetitions / repetitionsRequired;

--- a/lib/widgets/chord_diagram.dart
+++ b/lib/widgets/chord_diagram.dart
@@ -10,22 +10,33 @@ class ChordDiagram extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final int fretCount = (chord.maxFret <= 3) ? 4 : chord.maxFret + 1;
+    final int stringCount = chord.stringCount;
     final double height = 60 + fretCount * 48;
+    final double width = 48 + (stringCount - 1) * 44;
     return SizedBox(
-      width: 220,
+      width: width,
       height: height,
       child: CustomPaint(
-        painter: _ChordDiagramPainter(chord: chord, fretCount: fretCount),
+        painter: _ChordDiagramPainter(
+          chord: chord,
+          fretCount: fretCount,
+          stringCount: stringCount,
+        ),
       ),
     );
   }
 }
 
 class _ChordDiagramPainter extends CustomPainter {
-  _ChordDiagramPainter({required this.chord, required this.fretCount});
+  _ChordDiagramPainter({
+    required this.chord,
+    required this.fretCount,
+    required this.stringCount,
+  });
 
   final Chord chord;
   final int fretCount;
+  final int stringCount;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -40,10 +51,12 @@ class _ChordDiagramPainter extends CustomPainter {
     final double drawableHeight = size.height - topMargin - bottomMargin;
     final double fretGap = drawableHeight / fretCount;
     final double drawableWidth = size.width - (sideMargin * 2);
-    final double stringGap = drawableWidth / 3;
+    final double stringGap = stringCount > 1
+        ? drawableWidth / (stringCount - 1)
+        : drawableWidth;
 
     // Draw strings
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < stringCount; i++) {
       final double x = sideMargin + i * stringGap;
       canvas.drawLine(Offset(x, topMargin), Offset(x, size.height - bottomMargin), linePaint);
     }
@@ -65,7 +78,7 @@ class _ChordDiagramPainter extends CustomPainter {
 
     // Draw string labels and open string markers
     final List<int> frets = chord.stringFrets;
-    for (int string = 0; string < 4; string++) {
+    for (int string = 0; string < stringCount; string++) {
       final double x = sideMargin + string * stringGap;
       final double openY = topMargin - 16;
       if (frets[string] == 0) {


### PR DESCRIPTION
## Summary
- add an instrument model and extend the chord library with guitar tunings and shapes
- allow users to choose their instrument on the home screen and carry the selection into practice and exercise flows
- update practice and exercise view models, screens, and chord diagrams to adapt to variable string counts

## Testing
- Not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de192d47308326ac5a6b07e335913c