### PR TITLE
Adjust home layout and theme styling

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -12,11 +12,15 @@ class UkitarApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
           seedColor: Colors.teal,
-          brightness: Brightness.light,
+          brightness: Brightness.dark,
         ),
-        scaffoldBackgroundColor: const Color(0xFFF8FAFB),
+        scaffoldBackgroundColor: const Color(0xFF121212),
         useMaterial3: true,
-        textTheme: Typography.englishLike2021.apply(fontSizeFactor: 1.0),
+        textTheme: Typography.englishLike2021.apply(
+          fontSizeFactor: 1.0,
+          bodyColor: Colors.white,
+          displayColor: Colors.white,
+        ),
       ),
       home: const HomeScreen(),
     );

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -22,13 +22,19 @@ class _HomeScreenState extends State<HomeScreen> {
     final ThemeData theme = Theme.of(context);
     final String instrumentName = _selectedInstrument.displayName;
     final String instrumentNoun = _selectedInstrument.noun;
+    final ButtonStyle primaryButtonStyle = FilledButton.styleFrom(
+      minimumSize: const Size.fromHeight(48),
+      textStyle: theme.textTheme.titleMedium?.copyWith(
+        fontWeight: FontWeight.w600,
+      ),
+    );
     return Scaffold(
       body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 32.0, vertical: 48.0),
+        padding: const EdgeInsets.symmetric(horizontal: 32.0, vertical: 32.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-            const SizedBox(height: 64),
+            const SizedBox(height: 24),
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
@@ -85,70 +91,65 @@ class _HomeScreenState extends State<HomeScreen> {
               ),
             ),
             const SizedBox(height: 12),
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton(
-                onPressed: _showInstrumentPicker,
-                style: FilledButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(vertical: 20),
-                  textStyle: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
-                  ),
+            Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 320),
+                child: FilledButton(
+                  onPressed: _showInstrumentPicker,
+                  style: primaryButtonStyle,
+                  child: const Text('Choose Instrument'),
                 ),
-                child: const Text('Choose Instrument'),
-              ),
-            ),
-            const SizedBox(height: 12),
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton(
-                onPressed: () {
-                  Navigator.of(context).push(MaterialPageRoute<void>(
-                    builder: (BuildContext context) => PracticeScreen(
-                      instrument: _selectedInstrument,
-                    ),
-                  ));
-                },
-                style: FilledButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(vertical: 20),
-                  textStyle: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-                child: const Text('Start Practice'),
-              ),
-            ),
-            const SizedBox(height: 12),
-            SizedBox(
-              width: double.infinity,
-              child: FilledButton(
-                onPressed: () {
-                  Navigator.of(context).push(MaterialPageRoute<void>(
-                    builder: (BuildContext context) => ExerciseScreen(
-                      instrument: _selectedInstrument,
-                    ),
-                  ));
-                },
-                style: FilledButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(vertical: 20),
-                  textStyle: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-                child: const Text('Start Exercise'),
               ),
             ),
             const SizedBox(height: 12),
             Center(
-              child: FilledButton.icon(
-                onPressed: () => _openYoutubeChannel(context),
-                icon: const Icon(Icons.play_circle_fill),
-                label: const Text('Watch awiealissa on YouTube'),
-                style: FilledButton.styleFrom(
-                  backgroundColor: _youtubeRed,
-                  foregroundColor: Colors.white,
-                  textStyle: theme.textTheme.bodyMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 320),
+                child: FilledButton(
+                  onPressed: () {
+                    Navigator.of(context).push(MaterialPageRoute<void>(
+                      builder: (BuildContext context) => PracticeScreen(
+                        instrument: _selectedInstrument,
+                      ),
+                    ));
+                  },
+                  style: primaryButtonStyle,
+                  child: const Text('Start Practice'),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 320),
+                child: FilledButton(
+                  onPressed: () {
+                    Navigator.of(context).push(MaterialPageRoute<void>(
+                      builder: (BuildContext context) => ExerciseScreen(
+                        instrument: _selectedInstrument,
+                      ),
+                    ));
+                  },
+                  style: primaryButtonStyle,
+                  child: const Text('Start Exercise'),
+                ),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Center(
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 320),
+                child: FilledButton.icon(
+                  onPressed: () => _openYoutubeChannel(context),
+                  icon: const Icon(Icons.play_circle_fill),
+                  label: const Text('Watch awiealissa on YouTube'),
+                  style: FilledButton.styleFrom(
+                    backgroundColor: _youtubeRed,
+                    foregroundColor: Colors.white,
+                    minimumSize: const Size.fromHeight(48),
+                    textStyle: theme.textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary
- switch the application theme to a darker, grey-based palette
- tighten the hero spacing on the home screen so the header content sits closer to the top
- give the primary action buttons a consistent, more compact size that matches the YouTube button

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de2137278c83269cf1cec46c6caa97