### PR TITLE
Prefer high refresh rate when available

### DIFF
--- a/android/app/src/main/kotlin/com/example/ukitar/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/ukitar/MainActivity.kt
@@ -2,12 +2,20 @@ package com.example.ukitar
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
+import android.view.Display
+import android.view.Window
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
     private val channelName = "ukitar.external_launcher"
+
+    override fun onResume() {
+        super.onResume()
+        setPreferredRefreshRate()
+    }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -34,6 +42,35 @@ class MainActivity : FlutterActivity() {
             } else {
                 result.notImplemented()
             }
+        }
+    }
+
+    private fun setPreferredRefreshRate() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return
+        }
+
+        val activityDisplay: Display = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            display ?: return
+        } else {
+            @Suppress("DEPRECATION")
+            windowManager.defaultDisplay
+        }
+
+        val preferredMode = activityDisplay.supportedModes.maxByOrNull { it.refreshRate } ?: return
+
+        val layoutParams = window.attributes
+        if (layoutParams.preferredDisplayModeId != preferredMode.modeId) {
+            layoutParams.preferredDisplayModeId = preferredMode.modeId
+            window.attributes = layoutParams
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.setFrameRate(
+                preferredMode.refreshRate,
+                Window.FRAME_RATE_COMPATIBILITY_DEFAULT,
+                Window.CHANGE_FRAME_RATE_ALWAYS
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- add logic in the Android activity to choose the highest refresh rate display mode when the app resumes
- request the selected refresh rate through setFrameRate on Android 11 and above

## Testing
- flutter test *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de45905df08326b46e4f9281777214