### PR TITLE
Prefer high refresh rate when available

### DIFF
--- a/android/app/src/main/kotlin/com/example/ukitar/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/ukitar/MainActivity.kt
@@ -2,12 +2,20 @@ package com.example.ukitar
 
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
+import android.view.Display
+import android.view.Window
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
     private val channelName = "ukitar.external_launcher"
+
+    override fun onResume() {
+        super.onResume()
+        setPreferredRefreshRate()
+    }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -33,6 +41,53 @@ class MainActivity : FlutterActivity() {
                 }
             } else {
                 result.notImplemented()
+            }
+        }
+    }
+
+    private fun setPreferredRefreshRate() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return
+        }
+
+        val activityDisplay: Display = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            display ?: return
+        } else {
+            @Suppress("DEPRECATION")
+            windowManager.defaultDisplay
+        }
+
+        val preferredMode = activityDisplay.supportedModes.maxByOrNull { it.refreshRate } ?: return
+
+        val layoutParams = window.attributes
+        if (layoutParams.preferredDisplayModeId != preferredMode.modeId) {
+            layoutParams.preferredDisplayModeId = preferredMode.modeId
+            window.attributes = layoutParams
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val frameRate = preferredMode.refreshRate
+            runCatching {
+                val windowClass = Window::class.java
+                val setFrameRate = windowClass.getMethod(
+                    "setFrameRate",
+                    Float::class.javaPrimitiveType,
+                    Int::class.javaPrimitiveType,
+                    Int::class.javaPrimitiveType
+                )
+                val frameRateCompatibilityDefault = windowClass
+                    .getField("FRAME_RATE_COMPATIBILITY_DEFAULT")
+                    .getInt(null)
+                val changeFrameRateAlways = windowClass
+                    .getField("CHANGE_FRAME_RATE_ALWAYS")
+                    .getInt(null)
+
+                setFrameRate.invoke(
+                    window,
+                    frameRate,
+                    frameRateCompatibilityDefault,
+                    changeFrameRateAlways
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- fall back to reflective access for Window#setFrameRate and constants so builds succeed on projects compiling below API 30 while still requesting high refresh rates

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de45905df08326b46e4f9281777214